### PR TITLE
Update code-server-stack.yaml

### DIFF
--- a/code-server-stack.yaml
+++ b/code-server-stack.yaml
@@ -194,18 +194,11 @@ Resources:
             - |
               #!/bin/bash
               echo "INFO: Starting UserData script execution"
-              
-              # Wait for automatic apt updates to complete
-              echo "INFO: Waiting for automatic apt updates to complete"
-              while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
-                echo "INFO: Waiting for apt lock to be released..."
-                sleep 10
-              done
-              
+                          
               # Install AWS CLI
               echo "INFO: Installing AWS CLI prerequisites"
-              apt-get update
-              DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip
+              apt-get -o DPkg::Lock::Timeout=-1 update
+              DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=-1 install -y curl unzip
               echo "INFO: Prerequisites installed, downloading AWS CLI"
               curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip -o /tmp/aws-cli.zip
               echo "INFO: Extracting AWS CLI"


### PR DESCRIPTION
Added the -o DPkg::Lock::Timeout=-1 option to make the user data more robust. This flag will cause apt-get to wait until in can acquire a lock and proceed with package installation.

*Description of changes:* Simplified user data script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
